### PR TITLE
Updated publishing to SAR

### DIFF
--- a/buildspec_publish_to_sar.yml
+++ b/buildspec_publish_to_sar.yml
@@ -15,10 +15,12 @@ phases:
       - sam package --template-file .aws-sam/build/template.yaml --s3-bucket $S3_BUCKET --output-template-file sampackaged_raw.yaml
   post_build:
     commands:
-      # Getting latest version tag from git
+      # Setting a timestamp for the build in labels
+      - BUILD_TIMESTAMP=$(date -Iseconds)
+      - # Getting latest version tag from git
       - APPLICATION_VERSION=$(curl -s  https://api.github.com/repos/BIBSYSDEV/$GIT_REPO/releases/latest | jq -r '.tag_name')
       # Updating metadata.labels in template
-      - envsubst '${CODEBUILD_RESOLVED_SOURCE_VERSION},${GIT_REPO}' < sampackaged_raw.yaml > sampackaged.yaml
+      - envsubst '${CODEBUILD_RESOLVED_SOURCE_VERSION},${GIT_REPO},${BUILD_TIMESTAMP}' < sampackaged_raw.yaml > sampackaged.yaml
       # publishing to SAR
       - sam publish  --semantic-version $APPLICATION_VERSION  --template sampackaged.yaml
 artifacts:

--- a/template.yaml
+++ b/template.yaml
@@ -12,7 +12,7 @@ Metadata:
     Author: Unit
     SpdxLicenseId: MIT
     LicenseUrl: LICENSE
-    Labels: ['${CODEBUILD_RESOLVED_SOURCE_VERSION}', '${GIT_REPO}']
+    Labels: ['git-repo:${GIT_REPO}', 'git-commit:${CODEBUILD_RESOLVED_SOURCE_VERSION}', 'build@${BUILD_TIMESTAMP}']
     # SemanticVersion: is set via SAM command line
 
 Parameters:

--- a/template.yaml
+++ b/template.yaml
@@ -12,7 +12,7 @@ Metadata:
     Author: Unit
     SpdxLicenseId: MIT
     LicenseUrl: LICENSE
-    Labels: ['git-repo:${GIT_REPO}', 'git-commit:${CODEBUILD_RESOLVED_SOURCE_VERSION}', 'build@${BUILD_TIMESTAMP}']
+    Labels: ['git-repo:${GIT_REPO}', 'git-id:${CODEBUILD_RESOLVED_SOURCE_VERSION}', 'build@${BUILD_TIMESTAMP}']
     # SemanticVersion: is set via SAM command line
 
 Parameters:

--- a/template.yaml
+++ b/template.yaml
@@ -12,7 +12,7 @@ Metadata:
     Author: Unit
     SpdxLicenseId: MIT
     LicenseUrl: LICENSE
-    Labels: ['git-repo:${GIT_REPO}', 'git-id:${CODEBUILD_RESOLVED_SOURCE_VERSION}', 'build@${BUILD_TIMESTAMP}']
+    Labels: ['${GIT_REPO}', '${CODEBUILD_RESOLVED_SOURCE_VERSION}', '@${BUILD_TIMESTAMP}']
     # SemanticVersion: is set via SAM command line
 
 Parameters:


### PR DESCRIPTION
Template and buildspec updated to stick labels on publishing to SAR. 
When module is mature:
- merge to master
- do a git release from master, tagging with legal version number (<major>.<minor>.<patch>)

Module should appear in SAR with the updated labels; git-repo, git-id and build@<timestamp> 